### PR TITLE
Ignore local IDE settings

### DIFF
--- a/Drop Out/.gitignore
+++ b/Drop Out/.gitignore
@@ -1,0 +1,7 @@
+# Ignore IDE Generated Directories
+
+# Visual Studio Code
+.vscode
+
+# IntelliJ IDE
+.idea


### PR DESCRIPTION
IDE generated directories store local settings for a developer's IDE, so these are not needed in the repository.